### PR TITLE
fix: correct wording in corpus analysis resümee

### DIFF
--- a/corpus_analysis/corpus-analysis_resumee.md
+++ b/corpus_analysis/corpus-analysis_resumee.md
@@ -1,15 +1,15 @@
 # Resümee
 
-```{admonition} Key points des Kapitels
+```{admonition} Kernpunkte des Kapitels
 :class: keypoint
 
 **Textkomplexität**
-Es gibt verschiedene Textkomplexitätsmaße, die unterschiedliche Paramater zur Berechnung der Textkomplexität oder Lesbarkeit eines Textes einsetzen. Die Parameter lassen sich aufteilen in die Wort- und die Satzebene. Die meisten Scores lassen sich in eine Klassenstufe übersetzen, sodass ein leichter Text einen niedrige Score hat und ein schwerer Text einen hohen Score. 
+Es gibt verschiedene Textkomplexitätsmaße, die unterschiedliche Paramater zur Berechnung der Textkomplexität oder Lesbarkeit eines Textes einsetzen. Die Parameter lassen sich aufteilen in die Wort- und die Satzebene. Die meisten Scores lassen sich in eine Klassenstufe übersetzen, sodass ein leichter Text einen niedrigen Score hat und ein schwerer Text einen hohen Score.
 
 **Berechnung der Textkomplexität**
-Wir haben vier Maße zur Berechnung der Textkomplexität angewendet: Flesch (am weitesten verbreitet, operiert auf Satzlänge und Silbenanzahl), Wiener Sachtextformel (auf Deutsch ausgelegt, operiert auf Satzlänge und Anteil von schwierigen Wörtern), Automated Readability Score (operiert rein auf Längenmaßen) und Coleman-Liau (operiert auf der Gleichverteilheit der Textschrierigkeit).
-Die Maße haben wir mittels Python auf die Pressemitteilungen angewendet. 
+Wir haben vier Maße zur Berechnung der Textkomplexität angewendet: Flesch (am weitesten verbreitet, operiert auf Satzlänge und Silbenanzahl), Wiener Sachtextformel (auf Deutsch ausgelegt, operiert auf Satzlänge und Anteil von schwierigen Wörtern), Automated Readability Score (operiert rein auf Längenmaßen) und Coleman-Liau (operiert auf der Gleichverteilheit der Textschwierigkeit).
+Die Maße haben wir mittels Python auf die Pressemitteilungen angewendet.
 
-**Analyse und Visualisierung** 
-Die Analyse der Maße über Zeit hat gezeigt, dass alle Maße denselben Trend anzeigen: Die Pressemitteilungen werden über die Zeit komplexer, die Barrierefreiheit somit verringert. 
+**Analyse und Visualisierung**
+Die Analyse der Maße über Zeit hat gezeigt, dass alle Maße denselben Trend anzeigen: Die Pressemitteilungen werden über die Zeit komplexer, die Barrierefreiheit somit verringert.
 ```


### PR DESCRIPTION
## Summary

Fixes small spelling and wording issues in the corpus analysis resümee.

## Changes

- Replace the German/English admonition title with a German wording.
- Correct the adjective ending in “niedrigen Score”.
- Fix the typo “Textschrierigkeit”.

## Testing

- Inspected `corpus_analysis/corpus-analysis_resumee.md` directly.
- Ran `git diff --check`.

Fixes #167