### PR TITLE
fix: improve corpus analysis wording

### DIFF
--- a/corpus_analysis/corpus-analysis_analysis.ipynb
+++ b/corpus_analysis/corpus-analysis_analysis.ipynb
@@ -70,7 +70,7 @@
    },
    "source": [
     "## Einlesen der Daten und Metadaten\n",
-    "Exemplarisch lesen wir einen Text ein und extrahieren die Metadaten des Texts aus der Metadaten-Tabelle, um in einem späteren Schritt das Datum der Veröffentlichung extrahieren zu können, um die Textkomplexität diachron zu analysieren."
+    "Exemplarisch lesen wir einen Text ein und extrahieren die Metadaten des Texts aus der Metadaten-Tabelle. Damit können wir in einem späteren Schritt das Datum der Veröffentlichung bestimmen und die Textkomplexität diachron analysieren."
    ]
   },
   {
@@ -208,7 +208,7 @@
    "id": "6f4d0d65-729b-4bf5-8936-7f94a1d9f77a",
    "metadata": {},
    "source": [
-    "Ersten fünf Zeilen anzeigen lassen:"
+    "Die ersten fünf Zeilen anzeigen lassen:"
    ]
   },
   {
@@ -363,7 +363,7 @@
    "id": "c3e75deb-f624-4c14-998a-0b218bb48032",
    "metadata": {},
    "source": [
-    "Laut dem ARI wird der Text als äußerst schwieriger eingestuft und ist mit einem Score über 14 außerhalb der festgelegten Skala."
+    "Laut dem ARI wird der Text als äußerst schwierig eingestuft und ist mit einem Score über 14 außerhalb der festgelegten Skala."
    ]
   },
   {
@@ -397,7 +397,7 @@
    "id": "d18bc12c-99be-4c2a-953f-aa0524ce7b17",
    "metadata": {},
    "source": [
-    "Wie bei ARI liegt auch beim Coleman-Liau Index der Index außerhalb der angedachten Skala und ist somit als sehr schwierig zu beurteilen."
+    "Wie bei ARI liegt auch beim Coleman-Liau Index der Index außerhalb der angedachten Skala und weist somit auf einen sehr schwierigen Text hin."
    ]
   },
   {
@@ -564,7 +564,7 @@
    "metadata": {},
    "source": [
     "## Zusammenfügen der Scores mit den Metadaten \n",
-    "Korpusdaten mit dem Metadaten zusammenfügen. Die Einträge werden über den Dateinamen einander zugeordnet."
+    "Korpusdaten mit den Metadaten zusammenfügen. Die Einträge werden über den Dateinamen einander zugeordnet."
    ]
   },
   {


### PR DESCRIPTION
## Summary
- Improve wording and grammar in the corpus analysis notebook as requested.
- Remove awkward phrasing and correct article/adjective endings.

## Testing
- python3 -m json.tool corpus_analysis/corpus-analysis_analysis.ipynb
- Direct notebook content inspection with python3
- git diff --check

Fixes #163