### PR TITLE
fix: correct wording in visualization notebook

### DIFF
--- a/corpus_analysis/corpus-analysis_visualization.ipynb
+++ b/corpus_analysis/corpus-analysis_visualization.ipynb
@@ -159,7 +159,7 @@
     "  <summary><b>Informationen zum Ausführen des Notebooks – Zum Ausklappen klicken ⬇️</b></summary>\n",
     "Zuerst wird der Ordner angelegt, in dem die Textdateien gespeichert werden. Der Einfachheit halber wird die gleich Datenablagestruktur wie in dem <a href=\"https://github.com/dh-network/quadriga/tree/main\">GitHub Repository</a>, in dem die Daten gespeichert sind, vorausgesetzt. </br>\n",
     "Der Text wird aus GitHub heruntergeladen und in dem Ordner <i>../data/txt/</i> abgespeichert. </br>\n",
-    "Der Pfad kann in der Variable <i>text_path</i> angepasst werden. Die einzulesenden Daten müssen die Endung `.txt` haben. </br>\n",
+    "Der Pfad kann in der Variable <i>text_path</i> angepasst werden. Die einzulesenden Dateien müssen die Endung `.txt` haben. </br>\n",
     "</details>"
    ]
   },
@@ -255,7 +255,7 @@
    "id": "09fde2fa-5cd4-4962-94ab-cea5325c1206",
    "metadata": {},
    "source": [
-    "Erste 100 Zeilen der Daten angucken:"
+    "Erste 100 Zeilen angucken:"
    ]
   },
   {


### PR DESCRIPTION
Fixes #166

## Summary
- replace “Daten” with “Dateien” for the `.txt` file requirement
- remove “der Daten” from the first-100-lines instruction

## Validation
- inspected the edited notebook cells directly
- `git diff --check`